### PR TITLE
chore(rust): rust edition 2024

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         rust:
-          - 1.63.0  # MSRV
+          - 1.85.0  # MSRV
           - stable
           - beta
           - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "either"
 version = "1.15.0"
 authors = ["bluss"]
-edition = "2021"
+edition = "2024"
 rust-version = "1.85.0"
 
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "either"
 version = "1.15.0"
 authors = ["bluss"]
 edition = "2021"
-rust-version = "1.63.0"
+rust-version = "1.85.0"
 
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rayon-rs/either"

--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,10 @@ How to use with cargo::
 Recent Changes
 --------------
 
+- 1.16.0
+
+  - **MSRV**: ``either`` now requires Rust 1.85 or later.
+
 - 1.15.0
 
   - Fix ``serde`` support when building without ``std``, by @klkvr (#119)

--- a/src/into_either.rs
+++ b/src/into_either.rs
@@ -27,11 +27,7 @@ pub trait IntoEither: Sized {
     /// assert_eq!(x.into_either(false), Right(x));
     /// ```
     fn into_either(self, into_left: bool) -> Either<Self, Self> {
-        if into_left {
-            Left(self)
-        } else {
-            Right(self)
-        }
+        if into_left { Left(self) } else { Right(self) }
     }
 
     /// Converts `self` into a [`Left`] variant of [`Either<Self, Self>`](Either)

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -2,7 +2,7 @@ use super::{for_both, Either, Left, Right};
 use core::iter;
 
 macro_rules! wrap_either {
-    ($value:expr => $( $tail:tt )*) => {
+    ($value:expr_2021 => $( $tail:tt )*) => {
         match $value {
             Left(inner) => inner.map(Left) $($tail)*,
             Right(inner) => inner.map(Right) $($tail)*,

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -1,4 +1,4 @@
-use super::{for_both, Either, Left, Right};
+use super::{Either, Left, Right, for_both};
 use core::iter;
 
 macro_rules! wrap_either {

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -2,7 +2,7 @@ use super::{for_both, Either, Left, Right};
 use core::iter;
 
 macro_rules! wrap_either {
-    ($value:expr_2021 => $( $tail:tt )*) => {
+    ($value:expr => $( $tail:tt )*) => {
         match $value {
             Left(inner) => inner.map(Left) $($tail)*,
             Right(inner) => inner.map(Right) $($tail)*,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ pub enum Either<L, R> {
 /// ```
 #[macro_export]
 macro_rules! for_both {
-    ($value:expr, $pattern:pat => $result:expr) => {
+    ($value:expr_2021, $pattern:pat => $result:expr_2021) => {
         match $value {
             $crate::Either::Left($pattern) => $result,
             $crate::Either::Right($pattern) => $result,
@@ -111,7 +111,7 @@ macro_rules! for_both {
 /// ```
 #[macro_export]
 macro_rules! try_left {
-    ($expr:expr) => {
+    ($expr:expr_2021) => {
         match $expr {
             $crate::Left(val) => val,
             $crate::Right(err) => return $crate::Right(::core::convert::From::from(err)),
@@ -122,7 +122,7 @@ macro_rules! try_left {
 /// Dual to [`try_left!`], see its documentation for more information.
 #[macro_export]
 macro_rules! try_right {
-    ($expr:expr) => {
+    ($expr:expr_2021) => {
         match $expr {
             $crate::Left(err) => return $crate::Left(::core::convert::From::from(err)),
             $crate::Right(val) => val,
@@ -131,7 +131,7 @@ macro_rules! try_right {
 }
 
 macro_rules! map_either {
-    ($value:expr, $pattern:pat => $result:expr) => {
+    ($value:expr_2021, $pattern:pat => $result:expr_2021) => {
         match $value {
             Left($pattern) => Left($result),
             Right($pattern) => Right($result),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ pub enum Either<L, R> {
 /// ```
 #[macro_export]
 macro_rules! for_both {
-    ($value:expr_2021, $pattern:pat => $result:expr_2021) => {
+    ($value:expr, $pattern:pat => $result:expr) => {
         match $value {
             $crate::Either::Left($pattern) => $result,
             $crate::Either::Right($pattern) => $result,
@@ -111,7 +111,7 @@ macro_rules! for_both {
 /// ```
 #[macro_export]
 macro_rules! try_left {
-    ($expr:expr_2021) => {
+    ($expr:expr) => {
         match $expr {
             $crate::Left(val) => val,
             $crate::Right(err) => return $crate::Right(::core::convert::From::from(err)),
@@ -122,7 +122,7 @@ macro_rules! try_left {
 /// Dual to [`try_left!`], see its documentation for more information.
 #[macro_export]
 macro_rules! try_right {
-    ($expr:expr_2021) => {
+    ($expr:expr) => {
         match $expr {
             $crate::Left(err) => return $crate::Left(::core::convert::From::from(err)),
             $crate::Right(val) => val,
@@ -131,7 +131,7 @@ macro_rules! try_right {
 }
 
 macro_rules! map_either {
-    ($value:expr_2021, $pattern:pat => $result:expr_2021) => {
+    ($value:expr, $pattern:pat => $result:expr) => {
         match $value {
             Left($pattern) => Left($result),
             Right($pattern) => Right($result),


### PR DESCRIPTION
take following steps to migrate to 2024 edition:
- [X] cargo fix --edition
- [X] review all [macro fragment specifiers](https://doc.rust-lang.org/edition-guide/rust-2024/macro-fragment-specifiers.html), no conflicts with `const` or `_`
- [X] set MSRV 1.85.0
- [X] set edition to 2024
- [X] reformat `cargo fmt --all`
